### PR TITLE
removing 'std::endl;' and adding '\n'

### DIFF
--- a/src/calculator.cpp
+++ b/src/calculator.cpp
@@ -34,7 +34,7 @@ void Calculator::operation() {
 }
 
 void Calculator::m_set_result() {
-    std::cout << "\nresult: " << m_result << std::endl;
+    std::cout << "\nresult: " << m_result;
 
     history(m_result,  m_operation_type(m_oprt_type));
     m_sleep_timer(3);
@@ -108,22 +108,22 @@ void Calculator::m_handle_choice() {
                     break;
 
                 case 6:
-                    std::cout << "removing the logs folder..." << std::endl;
+                    std::cout << "removing the logs folder...\n";
                     std::filesystem::remove_all("logs/");
-                    std::cout << "logs folder removed" << std::endl;
+                    std::cout << "logs folder removed\n";
                     break;
 
                 default:
-                    std::cout << "ERROR: cannot found the good calcul method" << std::endl;
+                    std::cout << "ERROR: cannot found the good calcul method\n";
                     break;
             } // end of switch condition
 
         } else if (int(oprt) == 7) {
             save_history_count();
-            std::cout << "\nthank to use my calculator, bye!" << std::endl;
+            std::cout << "thank to use my calculator, bye!";
             std::exit(0);
         } else {
-            std::cout << "\nunknow option!\n" << std::endl;
+            std::cout << "unknow option!\n";
             oprt = 0;
             m_sleep_timer(3);
 

--- a/src/save_system.cpp
+++ b/src/save_system.cpp
@@ -16,7 +16,7 @@
 Calculator calc;
 
 void save_history_count() {
-    std::cout << "saving data" << std::endl;
+    std::cout << "saving data\n";
     std::ofstream file("logs/his_count.txt", std::ios::trunc);
 
     if (!std::filesystem::exists("logs/")) {
@@ -31,7 +31,7 @@ void save_history_count() {
 
 void load_history_count() {
 
-    std::cout << "loading data\n" << std::endl;
+    std::cout << "loading data\n";
     std::ifstream file("logs/his_count.txt");
 
     if (!std::filesystem::exists("logs/")) {
@@ -60,14 +60,14 @@ void history(float val, std::string oprt) {
     }
 
     if (!file) {
-        std::cerr << "CAUTION: cannot open the history file" << std::endl;
+        std::cerr << "CAUTION: cannot open the history file\n";
         return;
     }
 
-    file << "--------------------[HISTORY]--------------------" << std::endl;
+    file << "--------------------[HISTORY]--------------------\n";
     file << "HIS: " << std::to_string(calc.his) << ", TYPE: " << oprt
          << ", RESULT: " << val << std::endl;
-    file << "--------------------[  END  ]--------------------\n" << std::endl;
+    file << "--------------------[  END  ]--------------------\n";
 
     file.flush();
     file.close();

--- a/src/terminal_ui.cpp
+++ b/src/terminal_ui.cpp
@@ -16,16 +16,16 @@ UI::UI() {};
 UI::~UI() {};
 
 void UI::menu_display() const {
-    std::cout << "+========================+" << std::endl;
-    std::cout << "|  choose an option      |" << std::endl;
-    std::cout << "|  1) addition           |" << std::endl;
-    std::cout << "|  2) substraction       |" << std::endl;
-    std::cout << "|  3) multiplication     |" << std::endl;
-    std::cout << "|  4) division           |" << std::endl;
-    std::cout << "|  5) check logs         |" << std::endl;
-    std::cout << "|  6) delete logs        |" << std::endl;
-    std::cout << "|  7) quit               |" << std::endl;
-    std::cout << "+========================+" << std::endl;
+    std::cout << "+========================+\n";
+    std::cout << "|  choose an option      |\n";
+    std::cout << "|  1) addition           |\n";
+    std::cout << "|  2) substraction       |\n";
+    std::cout << "|  3) multiplication     |\n";
+    std::cout << "|  4) division           |\n";
+    std::cout << "|  5) check logs         |\n";
+    std::cout << "|  6) delete logs        |\n";
+    std::cout << "|  7) quit               |\n";
+    std::cout << "+========================+\n";
     std::cout << "option: ";
 }
 
@@ -42,9 +42,9 @@ void UI::logs_display() const {
                                    "[ENDING HISTORY DATA FILE]"
                                    "--------------------------\n";
 
-    std::cout << start_data_history << std::endl;
-    std::cout << system("cat logs/history.log") << std::endl;
-    std::cout << end_data_history << std::endl;
+    std::cout << start_data_history << "\n";
+    std::cout << system("cat logs/history.log") << "\n";
+    std::cout << end_data_history << "\n";
 }
 
 void UI::number_display() const {


### PR DESCRIPTION
i remove all `std::endl;` to replace them by '\n' method to safe space, avoid and increase compiling time